### PR TITLE
fix(sign): cannot notarize

### DIFF
--- a/krunkit.entitlements
+++ b/krunkit.entitlements
@@ -4,7 +4,9 @@
 <dict>
 	<key>com.apple.security.hypervisor</key>
 	<true/>
-	<key>com.apple.security.cs.disable-library-validationr</key>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
 	<true/>
 </dict>
 </plist>

--- a/main.sh
+++ b/main.sh
@@ -40,12 +40,12 @@ cd $WORK
 
 # codesign
 echo "Signing gvproxy..."
-codesign --force --sign $CODESIGN_IDENTITY --timestamp $WORK/out/gvproxy
+codesign --force --sign $CODESIGN_IDENTITY --options=runtime --timestamp $WORK/out/gvproxy
 
 echo "Signing krunkit..."
-codesign --force --sign $CODESIGN_IDENTITY --timestamp --entitlements krunkit.entitlements $WORK/out/krunkit
+codesign --force --sign $CODESIGN_IDENTITY --options=runtime --timestamp --entitlements krunkit.entitlements $WORK/out/krunkit
 
-find $WORK/out -name "*.dylib" -type f -exec sh -c "echo 'Signing {}...'; codesign --force --sign $CODESIGN_IDENTITY --timestamp {}" ';'
+find $WORK/out -name "*.dylib" -type f -exec sh -c "echo 'Signing {}...'; codesign --force --sign $CODESIGN_IDENTITY --options=runtime --timestamp {}" ';'
 
 # pack
 echo "Packing..."


### PR DESCRIPTION
When notarizing the APP, it's necessary to add `--options=runtime`.

At the same time, the issue of krun not being able to load dylib through env has been fixed, along with some spelling errors.