### PR TITLE
fix(krun): dylib is read-only

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -45,6 +45,7 @@ codesign --force --sign $CODESIGN_IDENTITY --options=runtime --timestamp $WORK/o
 echo "Signing krunkit..."
 codesign --force --sign $CODESIGN_IDENTITY --options=runtime --timestamp --entitlements krunkit.entitlements $WORK/out/krunkit
 
+find $WORK/out -name "*.dylib" -type f -exec sh -c "echo 'Set {} permission to 755'; chmod 755 {}" ';'
 find $WORK/out -name "*.dylib" -type f -exec sh -c "echo 'Signing {}...'; codesign --force --sign $CODESIGN_IDENTITY --options=runtime --timestamp {}" ';'
 
 # pack


### PR DESCRIPTION
When updating the app, if the dylib permissions are read-only, it will cause the app to fail to upgrade properly.

```txt
2024-11-04 14:46:50.214 ShipIt[44770:18196933]
Installation error: Error Domain=NSPOSIXErrorDomain Code=13 "Permission denied"
UserInfo={NSURL=file:///private/var/folders/v0/ny8b4zlj5kvb99qgb61mxyt00000gn/T/com.oomol.studio.ShipIt.8cxGhqSN/OOMOL%20Studio.app/Contents/Resources/app/node_modules/@oomol-lab/ovm/vm-resources/libexec/libkrun-efi.dylib,
NSLocalizedDescription=Permission denied,
NSLocalizedFailureReason=Couldn't remove quarantine attribute from "/private/var/folders/v0/ny8b4zlj5kvb99qgb61mxyt00000gn/T/com.oomol.studio.ShipIt.8cxGhqSN/OOMOL Studio.app/Contents/Resources/app/node_modules/@oomol-lab/ovm/vm-resources/libexec/libkrun-efi.dylib".
This most likely means the file is read-only.}
```